### PR TITLE
Document query language and update CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ Builds a call‑graph database. Server and client modes are placeholders and cur
 
 Global flags like --output-dir, --output-log-file, --print-profiler, and --use-file-timestamp apply to all commands. Use --version or --help-all for version info and comprehensive help.
 
+### Query language
+
+Commands that support the `--query` option accept a compact SQL-like language defined in
+[`KapaQuery.g4`](src/infrastructure/db/query/grammar/KapaQuery.g4).
+
+* Statements:
+  * `schema` prints the database tables with their columns.
+  * `list <table>` or `select <table>` optionally followed by a `where` clause returns rows from the
+    given table.
+* Filters combine a column name, an operator, and a quoted string literal. Supported operators are:
+  * `=` and `!=` for equality / inequality comparisons.
+  * `^*` (`not ^*`) for starts-with (and its negation).
+  * `*^` (`not *^`) for ends-with (and its negation).
+  * `*^*` for regular-expression matches.
+* String literals can use single (`'value'`) or double (`"value"`) straight quotes; double the quote
+  character to embed it inside the literal. Smart quotes copied from rich text, such as `“value”` or
+  `“value″`, are also accepted.
+* Logical composition uses parentheses together with `and` / `or`, e.g.
+  `(method ^* "com/example" and (owner = 'ClassName' or owner = 'OtherClass'))`.
+
+Combine `--query` with `--display-raw` to print unformatted column values when needed.
+
 Project Status
 Call‑graph server/client functionality is marked TODO and not yet implemented.
 

--- a/src/app/commands/DbBasedCommand.cpp
+++ b/src/app/commands/DbBasedCommand.cpp
@@ -77,8 +77,11 @@ bool DbBasedCommand::runAsClient() {
 }
 
 CLI::Option *DbBasedCommand::addQueryOptions() const {
-    const auto result = _subCommand->add_option("--query",_dbBasedOptions.queryValue, "TODO Query Help - schema");
-    _subCommand->add_flag("--display-raw",_dbBasedOptions.displayRaw, "Display row value of columns")
+    const auto result = _subCommand->add_option(
+        "--query",
+        _dbBasedOptions.queryValue,
+        "Run a database query; see README → Query language. Combine with --display-raw to print raw values.");
+    _subCommand->add_flag("--display-raw",_dbBasedOptions.displayRaw, "Display raw column values")
                ->needs(result);
     return result;
 }

--- a/src/app/commands/Query.h
+++ b/src/app/commands/Query.h
@@ -15,6 +15,7 @@ using infrastructure::db::Database;
 
 class Query {
 public:
+    /// Executes a query against the digest database when `--public-digest` is set, otherwise the call-graph database.
     static bool run(Context &config);
 
 private:


### PR DESCRIPTION
## Summary
- add a README section describing the supported database query language features
- clarify the `--query` CLI help text and mention the `--display-raw` flag
- document that the Query command targets the digest database when `--public-digest` is set and otherwise the call-graph database

## Testing
- not run (documentation and help text changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cdaf60e008832382d6cc0a15f623dc